### PR TITLE
Use system fonts in website

### DIFF
--- a/umu.openwinecomponents.org/index.php
+++ b/umu.openwinecomponents.org/index.php
@@ -34,6 +34,10 @@ if (isset($_POST["search"])) {
 <head>
     <title>Game Search</title>
     <style>
+      html {
+        font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+      }
+
       .results {
         border: 1px solid black;
       }


### PR DESCRIPTION
This pull request adjusts the HTML CSS to use the default system fonts which makes it look a bit nicer 😄 :

<img width="753" alt="Screenshot 2024-10-27 at 12 01 22" src="https://github.com/user-attachments/assets/8737a306-77fb-4ea2-a866-e5aa69e8eb0a">
