### PR TITLE
Adding Ys I and II

### DIFF
--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1060,3 +1060,5 @@ Dungeon Siege,none,none,umu-39190,,Cd Version
 Dungeon Siege 2,none,none,umu-39200,,Cd Version
 Redout: Enhanced Edition,egs,1be5efb848844b1dabf9d67f8017a7ae,umu-517710,,
 Kao the Kangaroo,egs,7763cb8916654651a50593a813ae7c38,umu-1370140,,Reboot from 2022.
+Ys I,gog,1422440106,umu-223810,,Part of the Ys I and II Chronicles+ pack
+Ys II,gog,1422440145,umu-223870,,Part of the Ys I and II Chronicles+ pack


### PR DESCRIPTION
Added `Ys I` and `Ys II` to the database.
These two games are always bundled together as part of the `Ys I and II Chronicles+` pack.

It might not make sense to add the pack itself to de database since we're never launching it, but let me know if that's necessary.

|Title |Steam ID |GOG ID |
|-------|--------------|------------|
|Ys I and II Chronicles+|[19230](https://steamdb.info/sub/19230/apps/)  |[1422357672](https://www.gogdb.org/product/1422357672#references)|
|Ys I|[223810](https://steamdb.info/app/223810/)|[1422440106](https://www.gogdb.org/product/1422440106)|
|Ys II|[223870](https://steamdb.info/app/223870/)|[1422440145](https://www.gogdb.org/product/1422440145)|