### PR TITLE
Add GOG versions of SpellForce 1 and 2 titles

### DIFF
--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1065,7 +1065,7 @@ Kao the Kangaroo,egs,7763cb8916654651a50593a813ae7c38,umu-1370140,,Reboot from 2
 Ys I,gog,1422440106,umu-223810,,Part of the Ys I and II Chronicles+ pack
 Ys II,gog,1422440145,umu-223870,,Part of the Ys I and II Chronicles+ pack
 Ghostrunner 2,egs,cc3213f280df4b428e85b771c09d1891,umu-2144740,,
-Identity V,none,none,umu-identityv,,Mobile game with a PC "port" (mobile gameplay, but native executable).
+Identity V,none,none,umu-identityv,,Mobile game with a PC "port" (mobile gameplay but native executable).
 SpellForce Platinum,gog,1207658719,umu-39540,,
 SpellForce 2 - Anniversary Edition,gog,1123662938,umu-39550,,
 SpellForce 2 - Faith in Destiny,gog,1914219141,umu-65530,,

--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1065,7 +1065,6 @@ Kao the Kangaroo,egs,7763cb8916654651a50593a813ae7c38,umu-1370140,,Reboot from 2
 Ys I,gog,1422440106,umu-223810,,Part of the Ys I and II Chronicles+ pack
 Ys II,gog,1422440145,umu-223870,,Part of the Ys I and II Chronicles+ pack
 Ghostrunner 2,egs,cc3213f280df4b428e85b771c09d1891,umu-2144740,,
-Identity V,none,none,umu-identityv,,Mobile game with a PC "port" (mobile gameplay but native executable).
 SpellForce Platinum,gog,1207658719,umu-39540,,
 SpellForce 2 - Anniversary Edition,gog,1123662938,umu-39550,,
 SpellForce 2 - Faith in Destiny,gog,1914219141,umu-65530,,

--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1066,3 +1066,7 @@ Ys I,gog,1422440106,umu-223810,,Part of the Ys I and II Chronicles+ pack
 Ys II,gog,1422440145,umu-223870,,Part of the Ys I and II Chronicles+ pack
 Ghostrunner 2,egs,cc3213f280df4b428e85b771c09d1891,umu-2144740,,
 Identity V,none,none,umu-identityv,,Mobile game with a PC "port" (mobile gameplay, but native executable).
+SpellForce Platinum,gog,1207658719,umu-39540,,
+SpellForce 2 - Anniversary Edition,gog,1123662938,umu-39550,,
+SpellForce 2 - Faith in Destiny,gog,1914219141,umu-65530,,
+SpellForce 2 - Demons Of The Past,gog,1207660473,umu-245050,,


### PR DESCRIPTION
Add SpellForce titles from GOG, all require DirectPlay for multiplayer.