### PR TITLE
Add Anno 1800 from Ubisoft Store

### DIFF
--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1097,3 +1097,5 @@ The Lord of the Rings Online™,none,none,umu-212500,lotro,lotro website install
 DOOM (2016),gog,1390579243,umu-379720,,DRM free release of DOOM (2016)
 Breath of Fire IV,gog,1587885678,umu-1587885678,bof4,
 Marvel Rivals,egs,575efd0b5dd54429b035ffc8fe2d36d0,umu-2767030,,
+Anno 1800,ubisoft,4553,umu-916440,,
+


### PR DESCRIPTION
Note : There is also Anno 1800 Gold Edition which might have a different ubisoft game id