### PR TITLE
Fix invalid hexadecimal codename fields for EGS entries

### DIFF
--- a/umu-database.csv
+++ b/umu-database.csv
@@ -565,9 +565,9 @@ Far Cry 4,egs,cf87285950ba492bbdc370b9d265ea36,umu-298110,,
 Far Cry Blood Dragon,ubisoft,205,umu-233270,,
 Far Cry 3 Blood Dragon,egs,8b9fc0e3ee7d478abc047d1a3596c568,umu-233270,,
 Far Cry 2,ubisoft,85,umu-19900,,In game turn mouse sensitivity all the way up for mouse movement to work properly.
-Far Cry 2,egs,a0b8d4482f3d4f939f35f87a3f367865,umu-19900,,In game turn mouse sensitivity all the way up for mouse movement to work properly.
+Far Cry 2,egs,3b78108a811d497db768899400edd842,umu-19900,,In game turn mouse sensitivity all the way up for mouse movement to work properly.
 Far Cry 2,gog,1207659042,umu-19900,,In game turn mouse sensitivity all the way up for mouse movement to work properly.
-UNCHARTED™: Legacy of Thieves Collection,egs,8b2d6cf2b45b41f1abe91bc5b7c1e8f9,umu-1659420,,
+UNCHARTED™: Legacy of Thieves Collection,egs,0ef5f1eaa6be4d648f6e9252aa02c5cf,umu-1659420,,
 Breathedge,egs,0a20ccd3f1b3464da750a4dbf8c80d7c,umu-738520,,
 Tomb Raider I-III Remastered Starring Lara Croft,gog,1407750955,umu-2478970,,
 Tomb Raider I-III Remastered Starring Lara Croft,egs,1014022493bd421eb54dae5386502c06,umu-2478970,,
@@ -579,7 +579,7 @@ Yakuza: Like a Dragon,gog,1229228729,umu-1235140,,
 Ghost Master,gog,1207658687,umu-6200,,
 Alone in the Dark,gog,1177195295,umu-1310410,,
 Frostpunk 2,gog,1728870436,umu-1601580,,
-Frostpunk 2,egs,4f7cefeebf4d4804be3007283abe4895,umu-1601580,,
+Frostpunk 2,egs,b9fcd8cd104a4b31a99692128a8e4bb4,umu-1601580,,
 Disaster Report 4: Summer Memories,gog,1167113997,umu-1060210,,
 Disaster Report 4: Summer Memories,egs,6684d2b2f9764f5c9c1c59de162c8a8e,umu-1060210,,
 The Legend of Heroes: Trails in the Sky,gog,1207665083,umu-251150,,
@@ -1064,7 +1064,7 @@ Dungeon Siege,none,none,umu-39190,,Cd Version
 Dungeon Siege 2,none,none,umu-39200,,Cd Version
 Redout: Enhanced Edition,egs,1be5efb848844b1dabf9d67f8017a7ae,umu-517710,,
 Fallout: New Vegas Ultimate Edition,gog,1454587428,umu-22380,FNV,
-Fallout: New Vegas,egs,3428aaab2c674c98b3acb789dcfaa548,umu-22380,FNV,
+Fallout: New Vegas,egs,5daeb974a22a435988892319b3a4f476,umu-22380,FNV,
 Kao the Kangaroo,egs,7763cb8916654651a50593a813ae7c38,umu-1370140,,Reboot from 2022.
 Ys I,gog,1422440106,umu-223810,,Part of the Ys I and II Chronicles+ pack
 Ys II,gog,1422440145,umu-223870,,Part of the Ys I and II Chronicles+ pack
@@ -1106,7 +1106,7 @@ Darksiders Warmastered Edition,egs,2bc23fc2438c47ec8acb0641980f50c1,umu-50620,,e
 Darksiders,amazon,0505db62-2dab-4ca3-be13-7a9f8a2987b8,umu-50620,,egs release of Darksiders
 Chronology,gog,1207664613,umu-269330,,DRM free release of Chronology
 MudRunner,egs,Bulbul,umu-675010,,
-Guild Wars 2®,egs,10cab3b738244873bacb8ec7cef8128c,umu-1284210,gw2,Epic Games Store release of Guild Wars 2
+Guild Wars 2®,egs,8d87562b481d44dd938c6a34a87d7355,umu-1284210,gw2,Epic Games Store release of Guild Wars 2
 Guild Wars 2,none,none,umu-1284210,gw2,Standalone release of Guild Wars 2
 Akiba's Trip: Undead & Undressed,gog,2053169534,umu-333980,,
 Warhammer 40000: Dawn of War - Definitive Edition,gog,1296823600,umu-3556750,,


### PR DESCRIPTION
We have a subset of EGS entries with invalid codenames that were either the `Namespace` value or something different all together. With the correct codename value assigned with the App Name, now, clients like Heroic Games Launcher can apply the correct fix for those games. See the `README.md` in this repository for how the new `codename` values were acquired. 