### PR TITLE
Drop steam as supported store in CI

### DIFF
--- a/tools/preflight-check.py
+++ b/tools/preflight-check.py
@@ -4,7 +4,7 @@ import sys
 import os
 import csv
 
-SUPPORTED_STORES = ["amazon", "battlenet", "none", "egs", "ubisoft", "ea", "humble", "itchio", "steam", "gog", "zoomplatform"]
+SUPPORTED_STORES = ["amazon", "battlenet", "none", "egs", "ubisoft", "ea", "humble", "itchio", "gog", "zoomplatform"]
 
 def main():
     file = sys.argv[1]


### PR DESCRIPTION
Related to https://github.com/Open-Wine-Components/umu-database/pull/115. 

We only want to create and track games with fixes that are from non-Steam storefronts such as GOG. Also, putting protonfixes aside, an entry already implies that a built-in fix exists.