### PR TITLE
Add MONGIL: STAR DIVE egs release.

### DIFF
--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1187,3 +1187,4 @@ Assassins Creed I,egs,0b9d1072cd674b8b91c8e25e9d695ed9,umu-15100,,,AssassinsCree
 Oddworld: Stranger's Wrath HD,gog,1207658950,umu-15750,,,Strangers Wrath HD/Launcher.exe
 DEATH STRANDING 2: ON THE BEACH,egs,0099fdb24c5442b09486de5feb33aa8d,umu-3280350,,,
 Akiba's Trip: Undead & Undressed,gog,2053169534,umu-333980,,,
+MONGIL: STAR DIVE,egs,5d5ddd31bdd044649b2e254e048b9259,umu-1504db23d6774e51ac7f411a68af2f6a,,,

--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1187,4 +1187,4 @@ Assassins Creed I,egs,0b9d1072cd674b8b91c8e25e9d695ed9,umu-15100,,,AssassinsCree
 Oddworld: Stranger's Wrath HD,gog,1207658950,umu-15750,,,Strangers Wrath HD/Launcher.exe
 DEATH STRANDING 2: ON THE BEACH,egs,0099fdb24c5442b09486de5feb33aa8d,umu-3280350,,,
 Akiba's Trip: Undead & Undressed,gog,2053169534,umu-333980,,,
-MONGIL: STAR DIVE,egs,5d5ddd31bdd044649b2e254e048b9259,umu-1504db23d6774e51ac7f411a68af2f6a,,,
+MONGIL: STAR DIVE,egs,5d5ddd31bdd044649b2e254e048b9259,umu-5d5ddd31bdd044649b2e254e048b9259,,,


### PR DESCRIPTION
Game is only available on EGS for the time being.