### PR TITLE
add GOG releases of several id Tech games

### DIFF
--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1179,3 +1179,8 @@ Cxbx-Reloaded,none,none,umu-cxbxreloaded,,Original Xbox Emulator,CxbxReloaded/cx
 The Fruit of Grisaia,none,none,umu-gurikaji,,1024x576 resolution version,
 Senren * Banka,gog,1453911006,umu-1144400,,,
 Senren * Banka,none,none,umu-1144400,,,
+Soldier of Fortune: Platinum Edition,gog,1828104558,umu-1828104558,,,
+Medal of Honor: Allied Assault War Chest,gog,1207659126,umu-1207659126,,,
+Quake,gog,1440166133,umu-2310,,,
+Return to Castle Wolfenstein,gog,1443699418,umu-9010,,,
+Hexen II,gog,1798886022,umu-9060,,,


### PR DESCRIPTION
Adds GOG releases of Soldier of Fortune, Medal of Honor: Allied Assault War Chest, Quake, Return to Castle Wolfenstein, and Hexen II.