### PR TITLE
Add Control - GoG, EpicGames

### DIFF
--- a/umu-database.csv
+++ b/umu-database.csv
@@ -1199,3 +1199,5 @@ Heroes Chronicles [Chapter 5] - The World Tree,gog,1207661783,umu-1207661783,,,
 Heroes Chronicles [Chapter 6] - The Fiery Moon,gog,1207661793,umu-1207661793,,,
 Heroes Chronicles [Chapter 7] - Revolt of the Beastmasters,gog,1207661803,umu-1207661803,,,
 Heroes Chronicles [Chapter 8] - The Sword of Frost,gog,1207661813,umu-1207661813,,,
+Control,gog,2049187585,umu-870780,,,Control_DX12.exe
+Control,egs,Calluna,umu-870780,,,


### PR DESCRIPTION
It launches through umu with `GAMEID=umu-0` (no database entry). [gamebus-presenced](https://github.com/fschaupp/gamebus-presenced) resolved its title on a live system from the launchers' own install records; per-entry evidence below.

Rows for `umu-database.csv`:

```csv
TITLE,STORE,CODENAME,UMU_ID,COMMON ACRONYM (Optional),NOTE (Optional),EXE_STRINGS (Optional)
Control,gog,2049187585,umu-870780,,,Control_DX12.exe
Control,egs,Calluna,umu-870780,,,
```

## Evidence

- **Control** — store `gog`, codename `2049187585`, exe `Control_DX12.exe`; title from detectable (high confidence); id drafted from the game's Steam appid (detectable.json sku), collision-checked 2026-08-07.
- **Control** — store `egs`, codename `calluna`; title from heroic-config (high confidence); id drafted from the game's Steam appid (detectable.json sku), collision-checked 2026-08-07.

## Checklist

- [x] Titles match the store's spelling and capitalization
- [x] Every id follows the database rules (Steam appid when the game is on Steam)
- [x] Drafted ids collision-checked against the full database
- [x] Non-Steam ids contain a letter (a numeric id would be parsed as a SteamAppId)